### PR TITLE
Rename spring runtime build artifact to flit-spring-runtime

### DIFF
--- a/runtime/spring/build.gradle
+++ b/runtime/spring/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.flit'
-archivesBaseName = 'flit-undertow-runtime'
+archivesBaseName = 'flit-spring-runtime'
 sourceCompatibility = 1.8
 
 repositories {


### PR DESCRIPTION
The spring runtime build incorrectly set the build artifact to `flit-undertow-runtime`. This renames it, for less confusion.